### PR TITLE
fix: change base url to Waldo's node

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,20 @@
 Changelog
 =========
 
-Version 0.0.0
+Version 0.1.1
+=============
+
+fix: change base url to Waldo's node
+------------------------------------
+
+The gatekeeper base URL doesn't support the full API. This commit
+updates the URL to point to Waldo's node.
+
+Waldo's node doesn't guarantee high uptime, so users should have a
+fallback node.
+
+
+Version 0.1.0
 =============
 
 A synchronous client (AttoClient) with most of the GET methods implemented.

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -53,9 +53,7 @@ class AttoClient:
     Attributes:
         base_url: the node API's base URL
     """
-    def __init__(self,
-                 base_url='https://gatekeeper.live.application.atto.cash',
-                 **kwargs):
+    def __init__(self, base_url='https://h.tail006b6.ts.net/api', **kwargs):
         """Create a synchronous client with a connection to a node.
 
         Args:


### PR DESCRIPTION
The gatekeeper base URL doesn't support the full API. This commit
updates the URL to point to Waldo's node.

Waldo's node doesn't guarantee high uptime, so users should have a
fallback node.