### PR TITLE
fix: get_instants() default argument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+Version 0.1.2
+=============
+
+fix: get_instants() default argument
+------------------------------------
+
+The default argument of AttoClient.get_instants() was ``datetime.now()``.
+However, Python only evaluates default arguments once, so it did not reflect
+the current time.
+
+Now, the default argument is None, which is equivalent to
+datetime.now().
+
 Version 0.1.1
 =============
 

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -78,17 +78,19 @@ class AttoClient:
 #    def get_transaction(self, hash_):
 #        return Transaction(self._get_json(f'/transactions/{hash_}'))
 
-    def get_instants(self, instant=datetime.datetime.now()):
+    def get_instants(self, instant=None):
         """Return time information about the client and the server.
 
         Args:
-            instant: A datetime object
+            instant: A datetime object. Defaults to datetime.now().
 
         Returns:
             A dataclass containing the date and time of the client
             (client_instant), the date and time of the server (server_instant)
             and the time delta between the client and the server (difference).
         """
+        if not instant:
+            instant = datetime.datetime.now()
         instant = instant.astimezone(datetime.UTC).isoformat()
 
         @dataclasses.dataclass


### PR DESCRIPTION
The default argument was `datetime.now()`. However, Python only evaluates
default arguments once, so it did not reflect the current time.

Now, the default argument is None, which is equivalent to
`datetime.now()`.