### PR TITLE
docs: add Atto links to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,4 +112,7 @@ Need help?
 
 I'm always available in the `Atto Discord server`_. Feel free to get in touch.
 
+For some insight into what inspired me to write this library, see `this blog
+post <https://atto.cash/blog/writing-python-api-wrapper>`_.
+
 .. _Atto Discord server: https://discord.gg/TfQGzEdzKp

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ atto.py
 =======
 
 
-    A Python API wrapper for the Atto node API.
+    A Python API wrapper for the `Atto`_ node API.
 
 
 An instance of `AttoClient()` represents a connection to an Atto node.
@@ -78,6 +78,8 @@ Example output:
     DEAD...     2500000000
     ... 97 more lines ...
 
+.. _Atto: https://atto.cash/
+
 Installation
 ------------
 
@@ -103,3 +105,10 @@ query nodes, and can't post transactions. This will change once a testing
 framework has been set up.
 
 All classes and members should be fully documented soon.
+
+Need help?
+----------
+
+I'm always available in the `Atto Discord server`_. Feel free to get in touch.
+
+.. _Atto Discord server: https://discord.gg/TfQGzEdzKp

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,9 @@ atto.py
 An instance of `AttoClient()` represents a connection to an Atto node.
 Communication with the node happens through `AttoClient()`'s members.
 
-The methods wrap the information from API responses in the form of
-Python builtins and classes in this module, such as:
+The methods wrap the information from `API responses
+<https://atto.cash/api/node>`_ in the form of Python builtins and classes in
+this module, such as:
 
 * Account
 * Entry

--- a/src/attopy/__init__.py
+++ b/src/attopy/__init__.py
@@ -19,8 +19,8 @@ Typical usage example::
                                                 timeout=None):
             print(f'{entry.hash_[0:3]}...\\t{entry.amount}')
 
-Although this documentation should be sufficient, an API reference can be found
-at https://atto.cash/api/node.
+Although this documentation should be sufficient, an `API reference
+<https://atto.cash/api/node>`_ exists.
 """
 """This file is part of Atto.py.
 


### PR DESCRIPTION
Link to https://atto.cash/ (for SEO purposes) and to the Atto Discord server (to attract people there).