### PR TITLE
Convert fields

### DIFF
--- a/src/attopy/Account.py
+++ b/src/attopy/Account.py
@@ -14,16 +14,20 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>. 
 """
+from .convert import (_str_to_network, _str_to_algorithm, _raw_to_atto,
+                      _timestamp_to_datetime)
 class Account:
     # TODO: docstring
     def __init__(self, dict_):
         self.public_key = dict_['publicKey']
-        self.network = dict_['network']
+        self.network = _str_to_network(dict_['network'])
         self.version = dict_['version']
-        self.algorithm = dict_['algorithm']
+        self.algorithm = _str_to_algorithm(dict_['algorithm'])
         self.height = dict_['height']
-        self.balance = dict_['balance']
+        self.balance = _raw_to_atto(dict_['balance'])
         self.last_transaction_hash = dict_['lastTransactionHash']
-        self.last_transaction_timestamp = dict_['lastTransactionTimestamp']
-        self.representative_algorithm = dict_['representativeAlgorithm']
+        self.last_transaction_timestamp = _timestamp_to_datetime(
+                dict_['lastTransactionTimestamp'])
+        self.representative_algorithm = _str_to_algorithm(
+                dict_['representativeAlgorithm'])
         self.representative_public_key = dict_['representativePublicKey']

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -118,7 +118,7 @@ class AttoClient:
 
 #    TODO: not supported by gatekeeper node; can't test
 #    def latest_accounts_stream(self, public_key, *args, **kwargs):
-        public_key = _try_account_to_key(public_key)
+#        public_key = _try_account_to_key(public_key)
 #        with self._client.stream('get',
 #                                 f'accounts/stream',
 #                                 *args,

--- a/src/attopy/Block.py
+++ b/src/attopy/Block.py
@@ -14,17 +14,19 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>. 
 """
+from .convert import (_str_to_algorithm, _timestamp_to_datetime,
+                      _str_to_network, _raw_to_atto, _str_to_block_type)
 
 class Block:
     # TODO: docstring
     def __init__(self, dict_):
         self.public_key = dict_['publicKey']
         self.version = dict_['version']
-        self.algorithm = dict_['algorithm']
-        self.timestamp = dict_['timestamp']
-        self.network = dict_['network']
-        self.balance = dict_['balance']
-        self.type = dict_['type']
+        self.algorithm = _str_to_algorithm(dict_['algorithm'])
+        self.timestamp = _timestamp_to_datetime(dict_['timestamp'])
+        self.network = _str_to_network(dict_['network'])
+        self.balance = _raw_to_atto(dict_['balance'])
+        self.type = _str_to_block_type(dict_['type'])
         self.height = dict_.get('height')
         self.previous = dict_.get('previous')
         # TODO: not present (tested /transactions/{hash}/stream

--- a/src/attopy/Block.py
+++ b/src/attopy/Block.py
@@ -29,6 +29,8 @@ class Block:
         self.type = _str_to_block_type(dict_['type'])
         self.height = dict_.get('height')
         self.previous = dict_.get('previous')
-        # TODO: not present (tested /transactions/{hash}/stream
-        #self.representative_algorithm = dict_['representativeAlgorithm']
-        #self.representative_public_key = dict_['representativePublicKey']
+        self.representative_algorithm = dict_.get('representativeAlgorithm', None)
+        if self.representative_algorithm is not None:
+            self.representative_algorithm = _str_to_algorithm(
+                    self.representative_algorithm)
+        self.representative_public_key = dict_.get('representativePublicKey', None)

--- a/src/attopy/Entry.py
+++ b/src/attopy/Entry.py
@@ -14,20 +14,21 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>. 
 """
+from .convert import (_str_to_algorithm, _str_to_block_type, _raw_to_atto,
+                      _timestamp_to_datetime)
 
 class Entry:
     # TODO: docstring
     def __init__(self, dict_):
         self.hash_ = dict_['hash']
-        self.algorithm = dict_['algorithm']
+        self.algorithm = _str_to_algorithm(dict_['algorithm'])
         self.public_key = dict_['publicKey']
         self.height = dict_['height']
-        self.block_type = dict_['blockType']  # TODO: enum (all classes)
-        self.subject_algorithm = dict_['subjectAlgorithm']
+        self.block_type = _str_to_block_type(dict_['blockType'])
+        self.subject_algorithm = _str_to_algorithm(dict_['subjectAlgorithm'])
         self.subjectPublicKey = dict_['subjectPublicKey']
-
-        self.previous_balance = dict_['previousBalance']
-        self.balance = dict_['balance']
+        self.previous_balance = _raw_to_atto(dict_['previousBalance'])
+        self.balance = _raw_to_atto(dict_['balance'])
         self.amount = self.balance - self.previous_balance
         # TODO: not a POSIX timestamp?
         #self.timestamp = datetime.datetime.fromtimestamp(dict_['timestamp'])

--- a/src/attopy/Entry.py
+++ b/src/attopy/Entry.py
@@ -30,5 +30,4 @@ class Entry:
         self.previous_balance = _raw_to_atto(dict_['previousBalance'])
         self.balance = _raw_to_atto(dict_['balance'])
         self.amount = self.balance - self.previous_balance
-        # TODO: not a POSIX timestamp?
-        #self.timestamp = datetime.datetime.fromtimestamp(dict_['timestamp'])
+        self.timestamp = _timestamp_to_datetime(dict_['timestamp'])

--- a/src/attopy/Receivable.py
+++ b/src/attopy/Receivable.py
@@ -15,16 +15,16 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>. 
 """
 import datetime
+from .convert import _str_to_algorithm, _timestamp_to_datetime, _raw_to_atto
 
 class Receivable:
     # TODO: docstring
     def __init__(self, dict_):
         self.hash_ = dict_['hash']
         self.version = dict_['version']
-        self.algorithm = dict_['algorithm']
+        self.algorithm = _str_to_algorithm(dict_['algorithm'])
         self.public_key = dict_['publicKey']
-        # TODO: not a POSIX timestamp?
-        #self.timestamp = datetime.datetime.fromtimestamp(dict_['timestamp'])
-        self.receiver_algorithm = dict_['receiverAlgorithm']
+        self.timestamp = _timestamp_to_datetime(dict_['timestamp'])
+        self.receiver_algorithm = _str_to_algorithm(dict_['receiverAlgorithm'])
         self.receiver_public_key = dict_['receiverPublicKey']
-        self.amount = dict_['amount']
+        self.amount = _raw_to_atto(dict_['amount'])

--- a/src/attopy/__init__.py
+++ b/src/attopy/__init__.py
@@ -1,8 +1,8 @@
 """A Python interface for the Atto node API.
 
 This module includes the synchronous client AttoClient (for interacting with
-the API) as well as utility functions that may be needed during this
-interaction.
+the API) as well as utility classes and functions that may be needed during
+this interaction.
 
 Typical usage example::
 
@@ -52,28 +52,4 @@ finally:
     del version, PackageNotFoundError
 
 from .AttoClient import *
-import base64
-
-def address_to_key(address_without_protocol):
-    """Convert an address into a public key.
-
-    Addresses are base32-encoded strings that start with atto://. Public keys
-    are the decoded form, with the version and checksum removed.
-
-    Client API functions accept public keys, not addresses. Similarly, accounts
-    returned from API functions contain public keys, not addresses.
-
-    Args:
-        address: An address (which typically starts with atto://), with atto://
-            removed. The protocol (atto://) can be removed from an address using
-            ``address.removeprefix('atto://')``.
-    Return:
-        A public key in the form of a binary string that can be passed to the
-        Atto.py client API functions.
-    """
-    decoded = base64.b32decode(address_without_protocol.upper() + '===')
-
-    # The first byte is the version. The last five bytes are the checksum.
-    key_bytes_hex = (format(byte, '02X') for byte in decoded[1:-5])
-
-    return ''.join(key_bytes_hex)
+from .convert import *

--- a/src/attopy/convert.py
+++ b/src/attopy/convert.py
@@ -43,3 +43,27 @@ def address_to_key(address_without_protocol):
     key_bytes_hex = (format(byte, '02X') for byte in decoded[1:-5])
 
     return ''.join(key_bytes_hex)
+
+def _timestamp_to_datetime(timestamp):
+    return datetime.datetime.fromtimestamp(timestamp/1000)
+
+def _raw_to_atto(amount):
+    return amount / 1_000_000_000
+
+def _str_to_network(str_):
+    try:
+        return Network(str_)
+    except ValueError:
+        raise NotImplementedError(f'{str_} is not a known network')
+
+def _str_to_algorithm(str_):
+    try:
+        return Algorithm(str_)
+    except ValueError:
+        raise NotImplementedError(f'{str_} is not a known algorithm')
+
+def _str_to_block_type(str_):
+    try:
+        return BlockType(str_)
+    except ValueError:
+        raise NotImplementedError(f'{str_} is not a known block type')

--- a/src/attopy/convert.py
+++ b/src/attopy/convert.py
@@ -1,0 +1,45 @@
+"""Conversion functions between the API's types and our types"""
+"""
+This file is part of Atto.py.
+
+Atto.py is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>. 
+"""
+import base64
+import datetime
+from .field_types import *
+
+__all__ = ['address_to_key']
+
+def address_to_key(address_without_protocol):
+    """Convert an address into a public key.
+
+    Addresses are base32-encoded strings that start with atto://. Public keys
+    are the decoded form, with the version and checksum removed.
+
+    Client API functions accept public keys, not addresses. Similarly, accounts
+    returned from API functions contain public keys, not addresses.
+
+    Args:
+        address: An address (which typically starts with atto://), with atto://
+            removed. The protocol (atto://) can be removed from an address using
+            ``address.removeprefix('atto://')``.
+    Return:
+        A public key in the form of a binary string that can be passed to the
+        Atto.py client API functions.
+    """
+    decoded = base64.b32decode(address_without_protocol.upper() + '===')
+
+    # The first byte is the version. The last five bytes are the checksum.
+    key_bytes_hex = (format(byte, '02X') for byte in decoded[1:-5])
+
+    return ''.join(key_bytes_hex)

--- a/src/attopy/field_types.py
+++ b/src/attopy/field_types.py
@@ -1,0 +1,35 @@
+"""Enum versions of strings from the API
+
+String values correspond to strings received from the API.
+"""
+"""
+This file is part of Atto.py.
+
+Atto.py is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>. 
+"""
+from enum import StrEnum
+
+class Network(StrEnum):
+    LIVE = 'LIVE'
+    BETA = 'BETA'
+    DEV = 'DEV'
+    TEST = 'TEST'
+
+class Algorithm(StrEnum):
+    V1 = 'V1'
+
+class BlockType(StrEnum):
+    SEND = 'SEND'
+    RECEIVE = 'RECEIVE'
+    OPEN = 'OPEN'
+    CHANGE = 'CHANGE'


### PR DESCRIPTION
This PR causes some fields to get returned as enums, while timestamps get returned as datetime objects. Optional representative fields are also now accessible from Block.