### PR TITLE
feat: accept addresses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 0.4.0
+=============
+
+* feat: accept addresses
+
 Version 0.3.0
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,12 @@ Typical usage example:
 
 .. code-block:: python
 
-    from attopy import AttoClient, address_to_key
+    from attopy import AttoClient
     
-    ADDRESS = '<your_address>'.removeprefix('atto://')
+    ADDRESS = '<your_address>'
     
     with AttoClient() as node:
-        public_key = address_to_key(ADDRESS)
-        account = node.get_account(public_key)
+        account = node.get_account(ADDRESS)
         print(f'balance: {account.balance}')
     
         # print first 100 transactions

--- a/src/attopy/__init__.py
+++ b/src/attopy/__init__.py
@@ -6,10 +6,10 @@ this interaction.
 
 Typical usage example::
 
-    ADDRESS = 'ad7z3jdoeqwayzpaiafizb5su6zc2fyvbeg2wq5t3yfj3q5iuprx23z437juk'
+    ADDRESS = 'atto://ad7z3jdoeqwayzpaiafizb5su6zc2fyvbeg2wq5t3yfj3q5iuprx23z437juk'
 
     with AttoClient() as atto_client:
-        account = atto_client.get_account(address_to_key(ADDRESS))
+        account = atto_client.get_account(ADDRESS)
 
         # print first 100 transactions
         print('Hash\\tAmount')


### PR DESCRIPTION
After approving this PR, methods that accept public keys and Accounts will also accept addresses, with or without the `atto://` protocol prefix. This PR also updates the relevant documentation.

Fixes #15.