### PR TITLE
Update AttoClient API to be more Pythonic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+Version 0.5.0
+=============
+
+* feat: rename get_instants to instants
+* feat: rename latext_x_stream to x with unused account param
+* feat: rename get_account to account
+* feat: move account_stream to account(stream=True)
+* feat: rename entry_stream to entry
+* feat: move transaction_stream to transaction
+* feat: move entries_stream to entries
+* feat: rename receivables_stream to receivables
+* feat: move transactions_stream to transactions
+
 Version 0.4.0
 =============
 

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -154,28 +154,25 @@ class AttoClient:
                                 *args,
                                 **kwargs)
 
-    def entries_stream(self,
-                       account,
-                       from_,
-                       to,
-                       *args,
-                       **kwargs):
-        # TODO: docstring
-        public_key = _account_to_key(account)
-        yield from self._stream(f'accounts/{public_key}/entries/stream',
-                                Entry,
-                                params={'fromHeight': from_,
-                                        'toHeight': to},
-                                *args,
-                                **kwargs)
-
-    def entries(self, account=None, *args, stream=True, **kwargs):
+    def entries(self, account=None, *args, from_, to, stream=True, **kwargs):
         # TODO: docstring
         if not stream:
             raise ValueError(f'{stream=}')
 
-        yield from self._stream(f'accounts/entries/stream',
+        if account is None:
+            endpoint = 'accounts/entries/stream'
+            params = {}
+            if from_ is not None:
+                raise ValueError(f'{account=}, {from_=}')
+            if to is not None:
+                raise ValueError(f'{account=}, {to=}')
+        else:
+            endpoint = f'accounts/{_account_to_key(account)}/entries/stream'
+            params = {'fromHeight': from_, 'toHeight': to}
+
+        yield from self._stream(endpoint,
                                 Entry,
+                                params=params,
                                 *args,
                                 **kwargs)
 

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -134,8 +134,11 @@ class AttoClient:
 #            for line in stream.iter_lines():
 #                yield Account(json.loads(line))
     
-    def receivables_stream(self, account, min_amount=1, *args, **kwargs):
+    def receivables(self, account, *args, min_amount=1, stream=True, **kwargs):
         # TODO: docstring
+        if not stream:
+            raise ValueError(f'{stream=}')
+
         public_key = _account_to_key(account)
         yield from self._stream(f'accounts/{public_key}/receivables/stream',
                                 Receivable,

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -82,7 +82,13 @@ class AttoClient:
         """
         public_key = _account_to_key(account)
 
-        return Account(self._get_json(f'/accounts/{public_key}'))
+        if not stream:
+            return Account(self._get_json(f'/accounts/{public_key}'))
+
+        yield from self._stream(f'accounts/{public_key}/stream',
+                                Account,
+                                *args,
+                                **kwargs)
 
 #    TODO: not supported by gatekeeper node; can't test
 #    def get_transaction(self, hash_):
@@ -117,14 +123,6 @@ class AttoClient:
         return Instants(client_instant=client_instant,
                         server_instant=server_instant,
                         difference=difference)
-
-    def account_stream(self, account, *args, **kwargs):
-        # TODO: docstring
-        public_key = _account_to_key(account)
-        yield from self._stream(f'accounts/{public_key}/stream',
-                                Account,
-                                *args,
-                                **kwargs)
 
 #    TODO: not supported by gatekeeper node; can't test
 #    def latest_accounts_stream(self, public_key, *args, **kwargs):

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -142,8 +142,13 @@ class AttoClient:
                                 *args,
                                 **kwargs)
 
-    def entry_stream(self, hash_, *args, **kwargs):
+    # stream=False because "entry" is singular, and singular methods aren't
+    # streamed by default
+    def entry(self, hash_, *args, stream=False, **kwargs):
         # TODO: docstring
+        if not stream:
+            raise ValueError(f'{stream=}')
+
         yield from self._stream(f'accounts/entries/{hash_}/stream',
                                 Entry,
                                 *args,

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -166,8 +166,11 @@ class AttoClient:
                                 *args,
                                 **kwargs)
 
-    def latest_entries_stream(self, *args, **kwargs):
+    def entries(self, account=None, *args, stream=True, **kwargs):
         # TODO: docstring
+        if not stream:
+            raise ValueError(f'{stream=}')
+
         yield from self._stream(f'accounts/entries/stream',
                                 Entry,
                                 *args,
@@ -195,8 +198,11 @@ class AttoClient:
                                 *args,
                                 **kwargs)
 
-    def latest_transactions_stream(self, *args, **kwargs):
+    def transactions(self, account=None, *args, stream=True, **kwargs):
         # TODO: docstring
+        if not stream:
+            raise ValueError(f'{stream=}')
+        
         yield from self._stream(f'transactions/stream',
                                 Transaction,
                                 *args,

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -88,7 +88,7 @@ class AttoClient:
 #    def get_transaction(self, hash_):
 #        return Transaction(self._get_json(f'/transactions/{hash_}'))
 
-    def get_instants(self, instant=None):
+    def instants(self, instant=None):
         """Return time information about the client and the server.
 
         Args:

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -157,7 +157,8 @@ class AttoClient:
                                 *args,
                                 **kwargs)
 
-    def entries(self, account=None, *args, from_, to, stream=True, **kwargs):
+    def entries(self, account=None, *args, from_=None, to=None, stream=True,
+                **kwargs):
         # TODO: docstring
         if not stream:
             raise ValueError(f'{stream=}')
@@ -191,28 +192,23 @@ class AttoClient:
                                 *args,
                                 **kwargs)
 
-    def transactions_stream(self,
-                            account,
-                            from_,
-                            to,
-                            *args,
-                            **kwargs):
-        # TODO: docstring
-        public_key = _account_to_key(account)
-        yield from self._stream(f'accounts/{public_key}/transactions/stream',
-                                Transaction,
-                                params={'fromHeight': from_,
-                                        'toHeight': to},
-                                *args,
-                                **kwargs)
-
-    def transactions(self, account=None, *args, stream=True, **kwargs):
+    def transactions(self, account=None, *args, from_=None, to=None,
+                     stream=True, **kwargs):
         # TODO: docstring
         if not stream:
             raise ValueError(f'{stream=}')
         
-        yield from self._stream(f'transactions/stream',
+        if account is None:
+            endpoint = 'transactions/stream'
+            params = {}
+        else:
+            public_key = _account_to_key(account)
+            endpoint = f'accounts/{public_key}/transactions/stream'
+            params = {'fromHeight': from_, 'toHeight': to}
+
+        yield from self._stream(endpoint,
                                 Transaction,
+                                params=params,
                                 *args,
                                 **kwargs)
 

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -179,8 +179,13 @@ class AttoClient:
                                 *args,
                                 **kwargs)
 
-    def transaction_stream(self, hash_, *args, **kwargs):
+    # stream=False because "entry" is singular, and singular methods aren't
+    # streamed by default
+    def transaction(self, hash_, *args, stream=False, **kwargs):
         # TODO: docstring
+        if not stream:
+            raise ValueError(f'{stream=}')
+
         yield from self._stream(f'transactions/{hash_}/stream',
                                 Transaction,
                                 *args,

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -71,7 +71,7 @@ class AttoClient:
         self.base_url = base_url
         self._client = httpx.Client(base_url=base_url, **kwargs)
     
-    def get_account(self, account):
+    def account(self, account, stream=False):
         """Return an up-to-date Account object
 
         Args:


### PR DESCRIPTION
This PR simplifies some of the method names and combines methods that return the same type, but in a different context. For example, latest_entries_stream and entries_stream are combined into entries(stream=True) and entries(account=account, stream=True) respectfully.