### PR TITLE
fix: return Account instead of generator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.6.1
+=============
+
+* fix: AttoClient.account() now returns an Account object instead of a
+  generator when stream=False
+
 Version 0.6.0
 =============
 

--- a/src/attopy/AttoClient.py
+++ b/src/attopy/AttoClient.py
@@ -115,10 +115,10 @@ class AttoClient:
         if not stream:
             return Account(self._get_json(f'/accounts/{public_key}'), self)
 
-        yield from self._stream(f'accounts/{public_key}/stream',
-                                Account,
-                                *args,
-                                **kwargs)
+        return self._stream(f'accounts/{public_key}/stream',
+                            Account,
+                            *args,
+                            **kwargs)
 
     # stream=False because "entry" is singular, and singular methods aren't
     # streamed by default


### PR DESCRIPTION
After some changes to the API, AC.account() ended up being a generator, and returned a generator object regardless of the value of stream.

This commit replaces 'yield from' with 'return', ensuring that AC.account() remains a regular function and returns an Account object when stream=False, and a generator object when stream=True.